### PR TITLE
Set the correct webroot in the LE cron job.

### DIFF
--- a/templates/cron.d/letsencrypt.j2
+++ b/templates/cron.d/letsencrypt.j2
@@ -17,7 +17,7 @@
 
 # Renew /etc/letsencrypt/live/{{ item.domains|first }}/ certificate, SAN domains:{% for name in item.domains %} {{ name }}{% endfor %}
 
-{{ time.m % 60 }} {{ time.h + (time.m - time.m % 60) // 60  }} 14 * * root /opt/letsencrypt/letsencrypt-auto certonly --webroot --webroot-path /var/www/letsencrypt {%- for name in item.domains %} -d {{ name }}{% endfor %} --renew-by-default 2>&1 | logger -t letsencrypt
+{{ time.m % 60 }} {{ time.h + (time.m - time.m % 60) // 60  }} 14 * * root /opt/letsencrypt/letsencrypt-auto certonly --webroot --webroot-path {{ letsencrypt_webroot }} {%- for name in item.domains %} -d {{ name }}{% endfor %} --renew-by-default 2>&1 | logger -t letsencrypt
 {% endif %}
 {% if time.update({'m': time.m + 5}) %}{% endif %}
 {% endfor %}

--- a/templates/cron.d/letsencrypt.j2
+++ b/templates/cron.d/letsencrypt.j2
@@ -17,7 +17,7 @@
 
 # Renew /etc/letsencrypt/live/{{ item.domains|first }}/ certificate, SAN domains:{% for name in item.domains %} {{ name }}{% endfor %}
 
-{{ time.m % 60 }} {{ time.h + (time.m - time.m % 60) // 60  }} 14 * * root /opt/letsencrypt/letsencrypt-auto certonly --webroot --webroot-path {{ letsencrypt_webroot }} {%- for name in item.domains %} -d {{ name }}{% endfor %} --renew-by-default 2>&1 | logger -t letsencrypt
+{{ time.m % 60 }} {{ time.h + (time.m - time.m % 60) // 60  }} * * * root /opt/letsencrypt/letsencrypt-auto certonly --webroot --webroot-path {{ letsencrypt_webroot }} {%- for name in item.domains %} -d {{ name }}{% endfor %} --keep-until-expiring 2>&1 | logger -t letsencrypt
 {% endif %}
 {% if time.update({'m': time.m + 5}) %}{% endif %}
 {% endfor %}


### PR DESCRIPTION
The cron job had a hardcoded webroot instead of using the `letsencrypt_webroot` variable. This pull request fixes that.